### PR TITLE
Added a test for scipy's "sparse distance matrix"

### DIFF
--- a/nbs/03_sparse_matrices_test.ipynb
+++ b/nbs/03_sparse_matrices_test.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "24d0d630-261c-45ad-9373-0b1b1658c650",
+   "metadata": {},
+   "source": [
+    "# sparse distance matrix test\n",
+    "\n",
+    "Most entries in the distance matrix for the RGG are too large to be interesting and we filter them out when computing statistics, e.g. when computing the connectivity threshold the maximum radius we consider is $O( (log(n) / n)^{1/d} )$.\n",
+    "\n",
+    "If we only store the distances between vertices $x,y$ with $\\| x - y \\| \\leq R_{\\mathrm{max}}$ where $n R_{\\mathrm{max}}^d = O(\\log n)$ (a sensible upper bound for most statistics), then the amount of memory we need is $O(n \\log n )$ instead of $\\Theta(n^2)$, a significant improvement which should let us use RGGs with more than a few thousand vertices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50ccf893-3134-4195-b4e9-c11c3c587fbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from scipy.spatial import KDTree\n",
+    "from sys import getsizeof\n",
+    "import timeit\n",
+    "\n",
+    "rng = np.random.default_rng()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55b7abe2-fc65-4958-8560-9540d8d401d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def full_matrix_experiment(n,d=2):\n",
+    "    # generates the (full) distance matrix for an RGG with n points in [0,1]^d,\n",
+    "    # and returns the amount of memory it uses.\n",
+    "    V = rng.uniform(size=(n,d))\n",
+    "    dm =  np.linalg.norm(V[:,None,:] - V[None,:,:],axis=-1)\n",
+    "    return dm.size\n",
+    "\n",
+    "def sparse_matrix_experiment(n,r_max,d=2):\n",
+    "    V = rng.uniform(size=(n,d))\n",
+    "    tree = KDTree(V)\n",
+    "    sdm = tree.sparse_distance_matrix(tree, r_max)\n",
+    "    return sdm.count_nonzero()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca6b64be-8d36-46ae-942d-bddf10c5b1a0",
+   "metadata": {},
+   "source": [
+    "Let's check both the size of the resulting matrices, and how long it takes to generate them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8816f0b8-6ec2-4f08-982c-e4e25fea6f68",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of elements in the sparse distance matrix with radius 0.478: 6178320\n",
+      "Number of elements in the usual distance matrix:                    25000000\n",
+      "\n",
+      "Time taken to generate 5 sparse distance matrices (in seconds):\n"
+     ]
+    }
+   ],
+   "source": [
+    "n = 5000\n",
+    "d = 3\n",
+    "r = 4*(np.log(n)/n)**(1/d) # Quite a bit above the coverage threshold for the square, so the test isn't too biased in favour of the sparse matrix\n",
+    "reps = 5\n",
+    "\n",
+    "print(f'Number of elements in the sparse distance matrix with radius {r:.3f}: {sparse_matrix_experiment(n,r,d)}')\n",
+    "print(f'Number of elements in the usual distance matrix:                    {full_matrix_experiment(n,d)}\\n')\n",
+    "\n",
+    "print(f'Time taken to generate {reps} sparse distance matrices (in seconds):')\n",
+    "print(sum(timeit.repeat(f'sparse_matrix_experiment({n},{r},{d})',repeat=reps,globals=globals(),number=1)))\n",
+    "print(f'Time taken to generate {reps} usual distance matrices (in seconds):')\n",
+    "print(sum(timeit.repeat(f'full_matrix_experiment({n},{d})',repeat=reps,globals=globals(),number=1)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36bdaaf9-e4cf-4c09-a9e9-212a4118c5ae",
+   "metadata": {},
+   "source": [
+    "The results are interesting: I think they provide a good case for using sparse distance matrices. Maybe I'll do a few more experiments by trying to calculate the number of components using a sparse distance matrix: this may or may not be quicker.\n",
+    "\n",
+    "Generating a usual distance matrix is a bit quicker when $r = 4 ( \\frac{\\log n}{n} )^{1/d}$, but this is generally much larger than the coverage threshold. If $r = 2 (\\frac{\\log n}{n})^{1/d}$, then generating a sparse distance matrix seems faster (it's also possible to just convert a 2d numpy array straight into a scipy.sparse.dok_array type sparse array, so maybe we can do without the KDTree step. But I think for very large $n$ the KDTree will be faster than usual linear algebra).\n",
+    "\n",
+    "A sparse distance matrix contains many fewer elements than the usual distance matrix. For every non-zero element it does also store the indices, so maybe you should triple the number of elements to get a comparable storage space, but even so it's much smaller than the full distance matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6383eb7-b74b-4793-b57e-8ae46e6d689c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1098822"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n = 10000\n",
+    "r = 2*(np.log(n)/n)**(1/2)\n",
+    "sparse_matrix_experiment(n,r,d=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77a3200f-d413-4729-9899-3bd348e1d0e8",
+   "metadata": {},
+   "source": [
+    "In particular it's possible to compute sparse distance matrices for more points; my computer runs out of memory when trying to compute the full distance matrix for more than around 6,000 points."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Hi Xiaochuan,

I've added a notebook which tests replacing the distance matrix with a "sparse distance matrix" from scipy
https://docs.scipy.org/doc/scipy/reference/sparse.html 

Since most entries in the distance matrix are too large and so we never need to look them up, these data types should let us only store the lengths of edges which might exist in an RGG we're interested in, while still working like 2D arrays. I've only added a test to the notebooks folder, not changed any of the package's code.